### PR TITLE
Create /usr/local/vdata/config directory

### DIFF
--- a/provision/vivo/install.sh
+++ b/provision/vivo/install.sh
@@ -30,6 +30,8 @@ mysql -uroot -pvivo -e "CREATE DATABASE IF NOT EXISTS $VIVO_DATABASE DEFAULT CHA
 sudo mkdir -p $APPDIR
 #Make data directory
 sudo mkdir -p $DATADIR
+#Make config directory
+sudo mkdir -p $DATADIR/config
 
 #Setup permissions and switch to app dir.
 sudo chown -R vagrant:vagrant $APPDIR


### PR DESCRIPTION
On first run, the `provision/vivo/install.sh` attempts to [copy a file](https://github.com/lawlesst/vivo-vagrant/blob/a7ccd5472c09cfefa0ec492c4c11f201d02c3c94/provision/vivo/install.sh#L52) to the `/usr/local/vdata/config` directory in the vagrant box, but that directory does not exist:

```
++ cp /home/vagrant/provision/vivo/build.properties /usr/local/vivo/.
++ cp /home/vagrant/provision/vivo/runtime.properties /usr/local/vdata/.
++ cp /home/vagrant/provision/vivo/applicationSetup.n3 /usr/local/vdata/config/.
cp: cannot create regular file `/usr/local/vdata/config/.': No such file or directory
```

This fix creates that directory.