### PR TITLE
Install ca-cert to enable access to remote maven repositories.

### DIFF
--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -56,6 +56,9 @@ installJava
 installMaven
 installTomcat
 
+#ca-certificates-java must be explicitly installed as it is needed for maven based installation
+/var/lib/dpkg/info/ca-certificates-java.postinst configure
+
 # Make Karma scripts executable
 chmod +x /home/vagrant/provision/karma.sh
 


### PR DESCRIPTION

Getting java.security.InvalidAlgorithmParameterException as cacerts JKS keystore not configured.
Please find attached file for error log. 

[vivo_error.txt](https://github.com/lawlesst/vivo-vagrant/files/1451792/vivo_error.txt)

